### PR TITLE
Reproducing Build Error for https://github.com/viclovsky/swagger-coverage/issues/93

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,11 +56,14 @@ test {
 }
 
 dependencies {
-    compile("io.rest-assured:rest-assured:4.3.0")
-    compile("com.fasterxml.jackson.core:jackson-databind:2.11.0")
-    compile("com.github.viclovsky.swagger.coverage:swagger-coverage-rest-assured:1.3.0")
+    implementation("io.rest-assured:rest-assured:4.3.0")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.0")
+    
+    testImplementation("com.github.viclovsky:swagger-coverage-commandline:1.4.3")
+    testImplementation("com.github.viclovsky:swagger-coverage-commons:1.4.3")
+    testImplementation("com.github.viclovsky:swagger-coverage-rest-assured:1.4.3")
 
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.3.0")
-    testCompile("org.junit.jupiter:junit-jupiter-engine:5.3.0")
-    testCompile("org.junit.jupiter:junit-jupiter-params:5.3.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.3.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.3.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.3.0")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Jun 16 13:04:21 MSK 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bumped up Gradle Version and included dependencies to all swagger coverage modules with version 1.4.3. to reporduce build error.
Running Gradle build or buildDependents will cause the error